### PR TITLE
Check if device is using dark mode on load

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,20 @@ const SponsorPackage = `${process.env.PUBLIC_URL}/pdfs/sponsorship_package.pdf`;
 // PDF locations in public folder
 //const SponsorPackage = `${process.env.PUBLIC_URL}/pdfs/sponsorship_package.pdf`;
 
+function checkIfDarkModeOnLoad() {
+    /**
+     * Check if device using dark mode
+     * Auto switch to dark mode
+     * Function runs on load
+     */
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        window.localStorage.setItem("mode", "dark");
+    else
+        window.localStorage.setItem("mode", "light");
+}
+
 const App = () => {
+    checkIfDarkModeOnLoad();
     return (
         <BrowserRouter>
             <Switch>


### PR DESCRIPTION
Function added to natively check if device is using dark mode. It runs on load, and will switch website to dark mode if device is on dark mode.